### PR TITLE
Added support for reading api key and shared secret from config file

### DIFF
--- a/plugins/flickr.rb
+++ b/plugins/flickr.rb
@@ -564,8 +564,8 @@ class FlickrSetTag < Liquid::Tag
 
 end
 
-FlickRaw.api_key        = ENV['FLICKR_API_KEY']
-FlickRaw.shared_secret  = ENV['FLICKR_API_SECRET']
+FlickRaw.api_key        = ENV['FLICKR_API_KEY'] || Jekyll.configuration({})['flickr']['api_key']
+FlickRaw.shared_secret  = ENV['FLICKR_API_SECRET'] || Jekyll.configuration({})['flickr']['shared_secret']
 
 def flickrCached; $flickrCached ||= FlickrApiCached.new end
 Liquid::Template.register_tag("flickr_image", FlickrImageTag)


### PR DESCRIPTION
Fixes issue #6

This change allows the api key and shared secret to be read from _config.yml while still also allowing the environment variables to be set. Environment variables will override the values in _config.yml if both are set

Example:

``` YAML
flickr:
  api_key: <api_key>
  shared_secret: <shared_secret>
```
