### PR TITLE
flickr plugin ignores command line configuration

### DIFF
--- a/plugins/flickr.rb
+++ b/plugins/flickr.rb
@@ -453,7 +453,11 @@ class FlickrImageTag < Liquid::Tag
   end
 
   def render(context)
-    self.getHtml(@id, @size, @klass, @desc)
+     FlickRaw.api_key        = ENV['FLICKR_API_KEY'] || context.registers[:site].config['flickr']['api_key']
+     FlickRaw.shared_secret  = ENV['FLICKR_API_SECRET'] || context.registers[:site].config['flickr']['shared_secret']
+     self.getHtml(@id, @size, @klass, @desc)
+  rescue
+     $stderr.print("flickr.rb could not be configured. See documentation.\n")
   end
 
   def getHtml(id, size, klass, desc)
@@ -511,7 +515,11 @@ class FlickrSetTag < Liquid::Tag
   end
 
   def render(context)
-    getHtml(@id, @size, @showSetDesc)
+     FlickRaw.api_key        = ENV['FLICKR_API_KEY'] || context.registers[:site].config['flickr']['api_key']
+     FlickRaw.shared_secret  = ENV['FLICKR_API_SECRET'] || context.registers[:site].config['flickr']['shared_secret']
+     getHtml(@id, @size, @showSetDesc)
+  rescue
+     $stderr.print("flickr.rb could not be configured. See documentation.\n")
   end
 
   def getHtml(id, size, showSetDesc)
@@ -568,12 +576,6 @@ class FlickrSetTag < Liquid::Tag
 
 end
 
-begin
-  FlickRaw.api_key        = ENV['FLICKR_API_KEY'] || Jekyll.configuration({})['flickr']['api_key']
-  FlickRaw.shared_secret  = ENV['FLICKR_API_SECRET'] || Jekyll.configuration({})['flickr']['shared_secret']
-rescue
-  $stderr.print("flickr.rb could not be configured. See documentation.\n")
-end
 
 def flickrCached; $flickrCached ||= FlickrApiCached.new end
 Liquid::Template.register_tag("flickr_image", FlickrImageTag)


### PR DESCRIPTION
Currently the flickr plugin tries to initialize flickraw at the time of import. Since there is no other way to access the site configuration which ois already loaded, a default command line parameter override is used to generate a new site config from which the flickr configurations is picked up.

The problem is that if I use jekyll command line parameters like "--config _config.yml,_config_extra.yml", the flickr configuration is not picked up if it is mentioned in the second file.

In this patch, I am moving the initialization from import-time to render time where the context provides all the final configuration. ([Reference issue](https://github.com/jekyll/jekyll/issues/1578))

I am new to ruby, so I would completely understand if you do not find my code ruby-ish and prefer a cleaner alternative. I just wanted to keep my copy of the plugin in sync with your repo. :) 
